### PR TITLE
Add tests covering MuJoCo recording workflow

### DIFF
--- a/ei-vo/render/play.py
+++ b/ei-vo/render/play.py
@@ -1,4 +1,18 @@
+from typing import Optional, Tuple
+
 from .render_mj import play as render_play
 
-def play(model_path: str, traj, slow=1.0, hz=240.0, loop=False):
-    render_play(model_path, traj, slow, hz, loop)
+
+def play(model_path: str, traj, slow=1.0, hz=240.0, loop=False,
+         record_path: Optional[str] = None, record_fps: Optional[float] = None,
+         record_size: Optional[Tuple[int, int]] = None):
+    render_play(
+        model_path,
+        traj,
+        slow,
+        hz,
+        loop=loop,
+        record_path=record_path,
+        record_fps=record_fps,
+        record_size=record_size,
+    )

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,70 @@
+# Examples
+
+`examples` ディレクトリには Panda ロボットの MuJoCo モデルを使ったデモスクリプトが入っています。ここでは `demo_mj.py` の使い方と、軌道の準備・録画機能について説明します。
+
+## 前提条件
+
+- MuJoCo 2.x がインストールされ、`LD_LIBRARY_PATH` や `MUJOCO_PY_MJKEY_PATH` 等の環境変数が設定済みであること
+- Panda の MJCF (`panda.xml`) が手元にあること
+- Python 3.9 以降、および `requirements.txt` に記載の依存関係がインストールされていること
+
+## デモの実行
+
+角度ファイルを指定しない場合、スクリプトは内蔵のデモ軌道を生成して再生します。以下はウェイポイントデモを実時間で再生する例です。
+
+```bash
+python examples/demo_mj.py --model /path/to/panda.xml
+```
+
+### オプション
+
+| オプション | 説明 |
+| --- | --- |
+| `--angles PATH` | CSV / NPY / JSON 形式の関節角度ファイルを読み込みます (`shape=(T,7)`) |
+| `--deg` | 角度ファイルが度数法 [deg] のときに指定します (ラジアンに変換) |
+| `--hz FLOAT` | 再生周波数を Hz で指定します (デフォルト: 240.0) |
+| `--loop` | 再生をループさせます |
+| `--demo {wp,sine}` | 角度ファイル未指定時のデモ軌道を切り替えます |
+| `--segT FLOAT` | ウェイポイントデモの区間時間 [s] (デフォルト: 1.5) |
+| `--slow FLOAT` | 再生をスロー再生します (`>1` でゆっくり) |
+| `--record PATH` | 指定すると録画動画を保存します (例: `output.mp4`) |
+| `--recordFps FLOAT` | 録画動画のフレームレートを明示的に指定します |
+| `--recordSize W H` | 録画動画のサイズ (幅, 高さ) をピクセル単位で指定します |
+
+## 録画付きの実行
+
+録画したい場合は `--record` を指定してください。フレームレートや解像度を変更する場合は `--recordFps` と `--recordSize` を併用します。
+
+```bash
+python examples/demo_mj.py \
+    --model /path/to/panda.xml \
+    --record demo.mp4 \
+    --recordFps 60 \
+    --recordSize 1920 1080
+```
+
+録画時も通常のビューワ表示は保持され、終了時に動画ファイルが保存されます。
+
+## 軌道ファイルの準備
+
+`--angles` で読み込むファイルは 7 関節の角度列を表す 2 次元配列です。サンプルとして、CSV を NumPy で生成するコード例を以下に示します。
+
+```python
+import numpy as np
+
+# shape = (T, 7)
+angles = np.linspace(0, 1, 240)[:, None] * np.ones((1, 7))
+np.savetxt("traj.csv", angles, delimiter=",")
+```
+
+JSON や NPY 形式も同様に読み込めます。角度が度数法の場合は `--deg` を忘れずに指定してください。
+
+## テスト
+
+`tests/` にはデモスクリプトの読み込みや録画処理を検証する Pytest ベースのテストが含まれています。以下で実行できます。
+
+```bash
+pytest
+```
+
+MuJoCo のネイティブライブラリを必要としないようスタブが用意されているため、ローカル環境でもそのままテスト可能です。

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,10 +2,12 @@
 
 `examples` ディレクトリには Panda ロボットの MuJoCo モデルを使ったデモスクリプトが入っています。ここでは `demo_mj.py` の使い方と、軌道の準備・録画機能について説明します。
 
+リポジトリ内には学習用の簡易 MJCF（`examples/models/simple_panda.xml`）も同梱しています。外部の Panda モデルを持っていない場合は、この簡易モデルを `--model` に指定すると即座にデモを試せます。
+
 ## 前提条件
 
 - MuJoCo 2.x がインストールされ、`LD_LIBRARY_PATH` や `MUJOCO_PY_MJKEY_PATH` 等の環境変数が設定済みであること
-- Panda の MJCF (`panda.xml`) が手元にあること
+- Panda の MJCF (`panda.xml`) が手元にあること、または `examples/models/simple_panda.xml` を利用すること
 - Python 3.9 以降、および `requirements.txt` に記載の依存関係がインストールされていること
 
 ## デモの実行
@@ -14,6 +16,8 @@
 
 ```bash
 python examples/demo_mj.py --model /path/to/panda.xml
+# もしくは同梱の簡易モデルを使う場合
+python examples/demo_mj.py --model examples/models/simple_panda.xml
 ```
 
 ### オプション

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ python examples/demo_mj.py --model examples/models/simple_panda.xml
 | `--demo {wp,sine}` | 角度ファイル未指定時のデモ軌道を切り替えます |
 | `--segT FLOAT` | ウェイポイントデモの区間時間 [s] (デフォルト: 1.5) |
 | `--slow FLOAT` | 再生をスロー再生します (`>1` でゆっくり) |
-| `--record PATH` | 指定すると録画動画を保存します (例: `output.mp4`) |
+| `--record [PATH]` | 指定すると録画動画を保存します (例: `output.mp4`)。パスを省略した場合は `recordings/` 以下に自動保存 |
 | `--recordFps FLOAT` | 録画動画のフレームレートを明示的に指定します |
 | `--recordSize W H` | 録画動画のサイズ (幅, 高さ) をピクセル単位で指定します |
 
@@ -42,12 +42,15 @@ python examples/demo_mj.py --model examples/models/simple_panda.xml
 ```bash
 python examples/demo_mj.py \
     --model /path/to/panda.xml \
-    --record demo.mp4 \
+    --record recordings/demo.mp4 \
     --recordFps 60 \
     --recordSize 1920 1080
 ```
 
-録画時も通常のビューワ表示は保持され、終了時に動画ファイルが保存されます。
+`--record` にファイル名を付けずに指定した場合は、実行ディレクトリ直下の `recordings/demo_<日時>.mp4` に保存されます。録画時も通常のビューワ表示は保持され、終了時に動画ファイルが保存されます。
+
+> **Note**
+> `Recording was requested but the installed ei.play() does not accept a 'record_path' argument.` という警告が表示された場合は、利用している `ei` パッケージが古く、録画 API が未対応です。リポジトリのルートで `pip install -e .` を実行するか、最新版に更新してください。
 
 ## 軌道ファイルの準備
 

--- a/examples/demo_mj.py
+++ b/examples/demo_mj.py
@@ -85,6 +85,38 @@ def build_sine_demo(T_sec: float, hz: float) -> np.ndarray:
 # ---------------------------
 # メイン
 # ---------------------------
+def _resolve_record_destination(record_arg):
+    """Resolve the desired recording path.
+
+    Returns a tuple of ``(path_or_none, auto_dir)`` where ``auto_dir`` is the
+    directory that was auto-created when the caller did not supply an explicit
+    filename. ``auto_dir`` is ``None`` when the caller provided a concrete
+    destination.
+    """
+
+    if record_arg is None:
+        return None, None
+
+    record_value = os.fspath(record_arg)
+    record_value = record_value.strip()
+
+    if record_value == "":
+        base_dir = pathlib.Path.cwd() / "recordings"
+    else:
+        candidate = pathlib.Path(record_value)
+        if record_value.endswith(os.sep):
+            base_dir = candidate
+        elif candidate.exists() and candidate.is_dir():
+            base_dir = candidate
+        else:
+            return candidate.as_posix(), None
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    filename = f"demo_{timestamp}.mp4"
+    record_path = (base_dir / filename).as_posix()
+    return record_path, base_dir.as_posix()
+
+
 def _prepare_play_invocation(args, traj_obj):
     """Build argument lists for ``ei.play`` depending on its signature."""
 
@@ -157,7 +189,13 @@ def main():
     ap.add_argument("--demo", choices=["wp", "sine"], default="wp", help="角度ファイルが無い時のデモ種別: wp(ウェイポイント) / sine(サイン波)")
     ap.add_argument("--segT", type=float, default=1.5, help="デモ=wp の各区間時間 [s]")
     ap.add_argument("--slow", type=float, default=1.0, help="実時間のスロー倍率（>1でゆっくり）")
-    ap.add_argument("--record", default=None, help="録画動画の保存パス (例: output.mp4)")
+    ap.add_argument(
+        "--record",
+        nargs="?",
+        const="",
+        default=None,
+        help="録画動画の保存パス (例: output.mp4)。省略値またはディレクトリのみ指定時は recordings/ 以下に保存",
+    )
     ap.add_argument("--recordFps", type=float, default=None, help="録画フレームレート [fps]（省略時: 再生fpsと同じ）")
     ap.add_argument("--recordSize", type=int, nargs=2, metavar=("W", "H"), default=None,
                     help="録画映像の幅[px]と高さ[px]（省略時: 1280x720）")
@@ -166,6 +204,12 @@ def main():
 
     if not os.path.isfile(args.model):
         raise FileNotFoundError(args.model)
+
+    record_path, auto_dir = _resolve_record_destination(args.record)
+    args.record = record_path
+
+    if auto_dir is not None and record_path is not None:
+        print(f"[demo_mj] --record でファイル名が指定されなかったため {record_path} に保存します")
 
     # 軌道用意
     if args.angles is None:

--- a/examples/demo_mj.py
+++ b/examples/demo_mj.py
@@ -85,6 +85,11 @@ def main():
     ap.add_argument("--demo", choices=["wp", "sine"], default="wp", help="角度ファイルが無い時のデモ種別: wp(ウェイポイント) / sine(サイン波)")
     ap.add_argument("--segT", type=float, default=1.5, help="デモ=wp の各区間時間 [s]")
     ap.add_argument("--slow", type=float, default=1.0, help="実時間のスロー倍率（>1でゆっくり）")
+    ap.add_argument("--record", default=None, help="録画動画の保存パス (例: output.mp4)")
+    ap.add_argument("--recordFps", type=float, default=None, help="録画フレームレート [fps]（省略時: 再生fpsと同じ）")
+    ap.add_argument("--recordSize", type=int, nargs=2, metavar=("W", "H"), default=None,
+                    help="録画映像の幅[px]と高さ[px]（省略時: 1280x720）")
+
     args = ap.parse_args()
 
     if not os.path.isfile(args.model):
@@ -102,7 +107,15 @@ def main():
         if q.shape[1] != 7:
             q = q[:, :7]
 
-    play(args.model, traj=type("Traj", (), {"q": q}), slow=args.slow, loop=args.loop)
+    play(
+        args.model,
+        traj=type("Traj", (), {"q": q}),
+        slow=args.slow,
+        loop=args.loop,
+        record_path=args.record,
+        record_fps=args.recordFps,
+        record_size=tuple(args.recordSize) if args.recordSize else None,
+    )
 
 if __name__ == "__main__":
     main()

--- a/examples/models/simple_panda.xml
+++ b/examples/models/simple_panda.xml
@@ -8,7 +8,7 @@
   </default>
 
   <asset>
-    <texture name="sky" type="skybox" builtin="gradient" rgb1="0.4 0.6 0.8" rgb2="0 0 0"/>
+    <texture name="sky" type="skybox" builtin="gradient" width="512" height="512" rgb1="0.4 0.6 0.8" rgb2="0 0 0"/>
     <material name="arm" texture="sky" texrepeat="1 1" reflectance="0.05" specular="0.3" shininess="0.5"/>
   </asset>
 

--- a/examples/models/simple_panda.xml
+++ b/examples/models/simple_panda.xml
@@ -8,12 +8,13 @@
   </default>
 
   <asset>
-    <texture name="sky" type="skybox" builtin="gradient" width="512" height="512" rgb1="0.4 0.6 0.8" rgb2="0 0 0"/>
-    <material name="arm" texture="sky" texrepeat="1 1" reflectance="0.05" specular="0.3" shininess="0.5"/>
+    <texture name="sky" type="skybox" builtin="gradient" width="512" height="512" rgb1="0.65 0.75 0.9" rgb2="0.2 0.25 0.35"/>
+    <material name="arm" texture="sky" texrepeat="1 1" reflectance="0.08" specular="0.35" shininess="0.6"/>
   </asset>
 
   <worldbody>
-    <light name="top" pos="0 0 2.5" dir="0 0 -1" diffuse="0.8 0.8 0.8" specular="0.2 0.2 0.2"/>
+    <light name="top" pos="0 0 2.5" dir="0 0 -1" diffuse="1.1 1.1 1.1" specular="0.35 0.35 0.35" ambient="0.25 0.25 0.25"/>
+    <light name="fill" pos="-1.5 -1.5 1.5" dir="0.6 0.6 -0.5" diffuse="0.6 0.6 0.6" specular="0.2 0.2 0.2" ambient="0.15 0.15 0.15"/>
     <geom name="floor" type="plane" size="3 3 0.1" rgba="0.9 0.9 0.9 1"/>
 
     <body name="base" pos="0 0 0.1">

--- a/examples/models/simple_panda.xml
+++ b/examples/models/simple_panda.xml
@@ -1,0 +1,60 @@
+<mujoco model="panda_simple">
+  <compiler angle="radian" coordinate="local" inertiafromgeom="true"/>
+  <option gravity="0 0 -9.81" timestep="0.002" integrator="RK4"/>
+
+  <default>
+    <joint limited="true" damping="2" armature="0.01" stiffness="5"/>
+    <geom type="capsule" size="0.04 0.15" rgba="0.7 0.7 0.7 1" material="arm"/>
+  </default>
+
+  <asset>
+    <texture name="sky" type="skybox" builtin="gradient" rgb1="0.4 0.6 0.8" rgb2="0 0 0"/>
+    <material name="arm" texture="sky" texrepeat="1 1" reflectance="0.05" specular="0.3" shininess="0.5"/>
+  </asset>
+
+  <worldbody>
+    <light name="top" pos="0 0 2.5" dir="0 0 -1" diffuse="0.8 0.8 0.8" specular="0.2 0.2 0.2"/>
+    <geom name="floor" type="plane" size="3 3 0.1" rgba="0.9 0.9 0.9 1"/>
+
+    <body name="base" pos="0 0 0.1">
+      <geom type="box" size="0.08 0.08 0.1" rgba="0.2 0.2 0.2 1"/>
+      <site name="base_site" pos="0 0 0" size="0.01" rgba="1 0 0 0"/>
+
+      <body name="link1" pos="0 0 0.1">
+        <joint name="panda_joint1" type="hinge" axis="0 0 1" range="-2.8973 2.8973"/>
+        <geom fromto="0 0 0 0 0 0.3" size="0.05"/>
+
+        <body name="link2" pos="0 0 0.3" euler="0 90 0">
+          <joint name="panda_joint2" type="hinge" axis="0 0 1" range="-1.7628 1.7628"/>
+          <geom fromto="0 0 0 0 0 0.25" size="0.045"/>
+
+          <body name="link3" pos="0 0 0.25" euler="0 -90 0">
+            <joint name="panda_joint3" type="hinge" axis="0 0 1" range="-2.8973 2.8973"/>
+            <geom fromto="0 0 0 0 0 0.28" size="0.04"/>
+
+            <body name="link4" pos="0 0 0.28">
+              <joint name="panda_joint4" type="hinge" axis="0 1 0" range="-3.0718 -0.0698"/>
+              <geom fromto="0 0 0 0 0 0.25" size="0.035"/>
+
+              <body name="link5" pos="0 0 0.25" euler="0 90 0">
+                <joint name="panda_joint5" type="hinge" axis="0 0 1" range="-2.8973 2.8973"/>
+                <geom fromto="0 0 0 0 0 0.22" size="0.035"/>
+
+                <body name="link6" pos="0 0 0.22" euler="0 -90 0">
+                  <joint name="panda_joint6" type="hinge" axis="0 0 1" range="-0.0175 3.7525"/>
+                  <geom fromto="0 0 0 0 0 0.2" size="0.03"/>
+
+                  <body name="link7" pos="0 0 0.2">
+                    <joint name="panda_joint7" type="hinge" axis="0 1 0" range="-2.8973 2.8973"/>
+                    <geom fromto="0 0 0 0 0 0.18" size="0.03"/>
+                    <site name="ee_site" pos="0 0 0.18" size="0.015" rgba="0 0.5 1 0"/>
+                  </body>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+</mujoco>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 mujoco
+imageio[ffmpeg]
+pytest

--- a/tests/test_demo_mj.py
+++ b/tests/test_demo_mj.py
@@ -1,0 +1,86 @@
+import json
+import math
+import pathlib
+import sys
+import types
+
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+dummy_ei = types.ModuleType("ei")
+dummy_ei.play = lambda *args, **kwargs: None
+sys.modules.setdefault("ei", dummy_ei)
+
+from examples import demo_mj
+
+
+def test_load_angles_csv_in_degrees(tmp_path: pathlib.Path):
+    data = np.array([
+        [0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 999.0],
+        [90.0, 80.0, 70.0, 60.0, 50.0, 40.0, 30.0, -999.0],
+    ], dtype=float)
+    csv_path = tmp_path / "angles.csv"
+    np.savetxt(csv_path, data, delimiter=",", fmt="%.6f")
+
+    loaded = demo_mj.load_angles(str(csv_path), deg=True)
+
+    assert loaded.shape == (2, 7)
+    expected = np.deg2rad(data[:, :7])
+    np.testing.assert_allclose(loaded, expected)
+
+
+def test_load_angles_json_truncates_columns(tmp_path: pathlib.Path):
+    arr = np.array([
+        [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+    ])
+    json_path = tmp_path / "angles.json"
+    with json_path.open("w", encoding="utf-8") as f:
+        json.dump(arr.tolist(), f)
+
+    loaded = demo_mj.load_angles(str(json_path), deg=False)
+
+    assert loaded.shape == (2, 7)
+    np.testing.assert_allclose(loaded, arr[:, :7])
+
+
+def test_quintic_interpolation_hits_endpoints():
+    q0 = np.zeros(7)
+    q1 = np.ones(7) * math.pi
+    segment = demo_mj.quintic(q0, q1, T=1.0, dt=0.2)
+
+    assert np.allclose(segment[0], q0)
+    assert np.allclose(segment[-1], q1)
+    assert segment.shape[0] == 6  # inclusive of both endpoints (0.0 .. 1.0 step 0.2)
+    assert np.all(segment[1:] >= segment[:-1] - 1e-9)
+
+
+def test_build_demo_trajectory_concatenates_segments():
+    waypoints = np.array([
+        np.zeros(7),
+        np.ones(7),
+        np.ones(7) * 2,
+    ])
+    traj = demo_mj.build_demo_trajectory(waypoints, seg_T=1.0, hz=2.0)
+
+    # With hz=2 the dt is 0.5, so each quintic segment yields 3 samples.
+    # The function drops the last sample of each segment except the final waypoint.
+    assert traj.shape[0] == 5
+    np.testing.assert_allclose(traj[0], waypoints[0])
+    np.testing.assert_allclose(traj[-1], waypoints[-1])
+
+
+def test_build_sine_demo_bounds_and_shape():
+    traj = demo_mj.build_sine_demo(T_sec=1.0, hz=10.0)
+
+    assert traj.shape == (11, 7)
+
+    base = np.array([0.0, -0.6, 0.0, -1.8, 0.0, 1.4, 0.6])
+    amp = np.array([0.25, 0.15, 0.20, 0.25, 0.20, 0.20, 0.15])
+    lower = base - amp - 1e-6
+    upper = base + amp + 1e-6
+    assert np.all(traj >= lower)
+    assert np.all(traj <= upper)

--- a/tests/test_demo_mj.py
+++ b/tests/test_demo_mj.py
@@ -174,3 +174,36 @@ def test_prepare_play_invocation_includes_record_kwargs_when_supported():
         assert call_kwargs["record_size"] == (800, 600)
     finally:
         demo_mj.play = original_play
+
+
+def test_resolve_record_destination_defaults_to_recordings(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(demo_mj.time, "strftime", lambda fmt: "20240102-030405")
+
+    path, auto_dir = demo_mj._resolve_record_destination("")
+
+    expected_dir = tmp_path / "recordings"
+    expected_file = expected_dir / "demo_20240102-030405.mp4"
+
+    assert path == expected_file.as_posix()
+    assert auto_dir == expected_dir.as_posix()
+
+
+def test_resolve_record_destination_accepts_directory(tmp_path, monkeypatch):
+    target_dir = tmp_path / "movies"
+    target_dir.mkdir()
+    monkeypatch.setattr(demo_mj.time, "strftime", lambda fmt: "20240102-030405")
+
+    path, auto_dir = demo_mj._resolve_record_destination(str(target_dir))
+
+    assert path == (target_dir / "demo_20240102-030405.mp4").as_posix()
+    assert auto_dir == target_dir.as_posix()
+
+
+def test_resolve_record_destination_preserves_filename(tmp_path):
+    given = tmp_path / "out"
+
+    path, auto_dir = demo_mj._resolve_record_destination(given)
+
+    assert path == given.as_posix()
+    assert auto_dir is None

--- a/tests/test_render_recording.py
+++ b/tests/test_render_recording.py
@@ -1,0 +1,235 @@
+import importlib
+import importlib.util
+import math
+import pathlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def render_mj(monkeypatch):
+    root = pathlib.Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    for name in ["ei.render.render_mj", "ei.render", "ei"]:
+        sys.modules.pop(name, None)
+
+    dummy_mujoco = types.ModuleType("mujoco")
+
+    class DummyMjModel:
+        njnt = 7
+        jnt_type = np.array([0] * 7)
+        jnt_qposadr = np.arange(7)
+        jnt_range = np.tile(np.array([[-np.pi, np.pi]]), (7, 1))
+
+        @staticmethod
+        def from_xml_path(path):
+            return DummyMjModel()
+
+    class DummyMjData:
+        def __init__(self, model):
+            self.qpos = np.zeros(7)
+
+    class DummyRenderer:
+        def __init__(self, model, height, width):
+            self.model = model
+            self.height = height
+            self.width = width
+            self.closed = False
+
+        def update_scene(self, data, camera=None):
+            pass
+
+        def render(self):
+            return np.zeros((self.height, self.width, 3), dtype=np.uint8)
+
+        def close(self):
+            self.closed = True
+
+    class DummyCamera:
+        def __init__(self):
+            self.distance = 0.0
+            self.azimuth = 0.0
+            self.elevation = 0.0
+            self.lookat = np.zeros(3)
+
+    def mjv_default_camera(cam):
+        cam.distance = 1.9
+        cam.azimuth = 110.0
+        cam.elevation = -20.0
+        cam.lookat[:] = 0.0
+
+    dummy_mujoco.MjModel = DummyMjModel
+    dummy_mujoco.MjData = DummyMjData
+    dummy_mujoco.Renderer = DummyRenderer
+    dummy_mujoco.MjvCamera = DummyCamera
+    dummy_mujoco.mjtJoint = types.SimpleNamespace(mjJNT_HINGE=0)
+    dummy_mujoco.mjtObj = types.SimpleNamespace(mjOBJ_JOINT=0)
+    dummy_mujoco.mj_id2name = lambda m, obj, j_id: f"joint{j_id + 1}"
+    dummy_mujoco.mjv_defaultCamera = mjv_default_camera
+    dummy_mujoco.mj_forward = lambda m, d: None
+
+    class DummyViewer:
+        def __init__(self):
+            self.cam = types.SimpleNamespace(
+                distance=1.9,
+                azimuth=110.0,
+                elevation=-20.0,
+                lookat=np.zeros(3),
+            )
+            self._states = [True, False]
+
+        def is_running(self):
+            return self._states.pop(0) if self._states else False
+
+        def sync(self):
+            pass
+
+    class DummyViewerContext:
+        def __enter__(self):
+            return DummyViewer()
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    viewer_module = types.ModuleType("mujoco.viewer")
+    viewer_module.launch_passive = lambda model, data: DummyViewerContext()
+
+    monkeypatch.setitem(sys.modules, "mujoco", dummy_mujoco)
+    monkeypatch.setitem(sys.modules, "mujoco.viewer", viewer_module)
+
+    package_root = root / "ei-vo"
+
+    ei_pkg = types.ModuleType("ei")
+    ei_pkg.__path__ = [str(package_root)]
+    core_pkg = types.ModuleType("ei.core")
+    core_pkg.__path__ = [str(package_root / "core")]
+    render_pkg = types.ModuleType("ei.render")
+    render_pkg.__path__ = [str(package_root / "render")]
+
+    monkeypatch.setitem(sys.modules, "ei", ei_pkg)
+    monkeypatch.setitem(sys.modules, "ei.core", core_pkg)
+    monkeypatch.setitem(sys.modules, "ei.render", render_pkg)
+
+    core_spec = importlib.util.spec_from_file_location(
+        "ei.core.core", package_root / "core" / "core.py"
+    )
+    core_module = importlib.util.module_from_spec(core_spec)
+    monkeypatch.setitem(sys.modules, "ei.core.core", core_module)
+    core_spec.loader.exec_module(core_module)
+
+    render_spec = importlib.util.spec_from_file_location(
+        "ei.render.render_mj", package_root / "render" / "render_mj.py"
+    )
+    module = importlib.util.module_from_spec(render_spec)
+    monkeypatch.setitem(sys.modules, "ei.render.render_mj", module)
+    render_spec.loader.exec_module(module)
+
+    ei_pkg.render = render_pkg
+    render_pkg.render_mj = module
+    return module
+
+
+def test_init_recording_defaults(tmp_path, render_mj, monkeypatch):
+    captured = {}
+
+    class DummyWriter:
+        def __init__(self, path, fps):
+            captured["path"] = path
+            captured["fps"] = fps
+            self.closed = False
+
+        def append_data(self, frame):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    imageio_v2 = types.ModuleType("imageio.v2")
+    imageio_v2.get_writer = lambda path, fps: DummyWriter(path, fps)
+    imageio_module = types.ModuleType("imageio")
+    imageio_module.v2 = imageio_v2
+
+    monkeypatch.setitem(sys.modules, "imageio", imageio_module)
+    monkeypatch.setitem(sys.modules, "imageio.v2", imageio_v2)
+
+    renderer, camera, writer = render_mj._init_recording(
+        render_mj.mj.MjModel.from_xml_path("dummy.xml"),
+        dt=0.01,
+        record_path=tmp_path / "video",
+        record_fps=None,
+        record_size=None,
+    )
+
+    assert isinstance(renderer, render_mj.mj.Renderer)
+    assert renderer.width == 1280 and renderer.height == 720
+    assert isinstance(camera, render_mj.mj.MjvCamera)
+    assert math.isclose(captured["fps"], 100.0)
+    assert captured["path"].endswith("video.mp4")
+    assert isinstance(writer, DummyWriter)
+
+
+def test_play_records_frames(tmp_path, render_mj, monkeypatch):
+    frames = []
+    closed = {"renderer": False, "writer": False}
+
+    class DummyRenderer:
+        def __init__(self, *args, **kwargs):
+            self.height = 3
+            self.width = 4
+
+        def update_scene(self, data, camera=None):
+            pass
+
+        def render(self):
+            return np.full((self.height, self.width, 3), 0.5, dtype=float)
+
+        def close(self):
+            closed["renderer"] = True
+
+    class DummyCamera:
+        def __init__(self):
+            self.distance = 0.0
+            self.azimuth = 0.0
+            self.elevation = 0.0
+            self.lookat = np.zeros(3)
+
+    class DummyWriter:
+        def append_data(self, frame):
+            frames.append(frame)
+
+        def close(self):
+            closed["writer"] = True
+
+    captured_camera = {}
+
+    def fake_init(model, dt, record_path, record_fps, record_size):
+        camera = DummyCamera()
+        captured_camera["camera"] = camera
+        return DummyRenderer(), camera, DummyWriter()
+
+    monkeypatch.setattr(render_mj, "_init_recording", fake_init)
+    monkeypatch.setattr(render_mj.time, "sleep", lambda _: None)
+
+    traj = types.SimpleNamespace(q=np.linspace(0.0, 1.0, 21, dtype=float).reshape(3, 7))
+
+    render_mj.play(
+        "model.xml",
+        traj,
+        slow=1.0,
+        hz=10.0,
+        loop=False,
+        record_path=tmp_path / "out.mp4",
+        record_fps=None,
+        record_size=None,
+    )
+
+    assert len(frames) == traj.q.shape[0]
+    assert all(frame.dtype == np.uint8 for frame in frames)
+    assert np.all(frames[0] == 127)  # 0.5 * 255 rounded down
+    assert captured_camera["camera"].distance == pytest.approx(1.9)
+    assert closed["renderer"] and closed["writer"]


### PR DESCRIPTION
## Summary
- add a stubbed MuJoCo setup so the renderer can be imported without the native dependency
- test `_init_recording` default behaviour and frame capture when recording playback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e325edc0208321b999f880e53bb7a6