### PR TITLE
Extract quintic interpolation utility

### DIFF
--- a/ei_vo/__init__.py
+++ b/ei_vo/__init__.py
@@ -2,5 +2,13 @@
 # -*- coding: utf-8 -*-
 # 2025.10.01 Created by T.Ishigaki
 
-from .core import *
-from .render import play
+from .core import load_angles, quintic, RobotModel, Trajectory
+from .render.play import play
+
+__all__ = [
+    "load_angles",
+    "quintic",
+    "RobotModel",
+    "Trajectory",
+    "play",
+]

--- a/ei_vo/__init__.py
+++ b/ei_vo/__init__.py
@@ -2,12 +2,19 @@
 # -*- coding: utf-8 -*-
 # 2025.10.01 Created by T.Ishigaki
 
-from .core import load_angles, quintic, RobotModel, Trajectory
+from .core import (
+    load_angles,
+    quintic,
+    resolve_record_destination,
+    RobotModel,
+    Trajectory,
+)
 from .render.play import play
 
 __all__ = [
     "load_angles",
     "quintic",
+    "resolve_record_destination",
     "RobotModel",
     "Trajectory",
     "play",

--- a/ei_vo/core/__init__.py
+++ b/ei_vo/core/__init__.py
@@ -1,10 +1,12 @@
 from .angles import load_angles
 from .core import RobotModel, Trajectory
 from .interpolation import quintic
+from .recording import resolve_record_destination
 
 __all__ = [
     "load_angles",
     "RobotModel",
     "Trajectory",
     "quintic",
+    "resolve_record_destination",
 ]

--- a/ei_vo/core/__init__.py
+++ b/ei_vo/core/__init__.py
@@ -1,0 +1,10 @@
+from .angles import load_angles
+from .core import RobotModel, Trajectory
+from .interpolation import quintic
+
+__all__ = [
+    "load_angles",
+    "RobotModel",
+    "Trajectory",
+    "quintic",
+]

--- a/ei_vo/core/angles.py
+++ b/ei_vo/core/angles.py
@@ -1,0 +1,59 @@
+"""Angle loading helpers shared across demos and utilities."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Iterable
+
+import numpy as np
+
+
+def load_angles(path: str | pathlib.Path, deg: bool) -> np.ndarray:
+    """Load a ``(T, DOF)`` array of joint angles from ``CSV``/``NPY``/``JSON``.
+
+    Parameters
+    ----------
+    path:
+        Path to the input file. Supported extensions are ``.csv``, ``.npy``,
+        and ``.json`` (case-insensitive).
+    deg:
+        Whether the provided angles are in degrees. When ``True`` the data is
+        converted to radians before returning.
+
+    Returns
+    -------
+    np.ndarray
+        A ``float`` array with shape ``(T, DOF)``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If the file extension is unsupported or the loaded array is not 2-D.
+    """
+
+    p = pathlib.Path(path)
+    if not p.exists():
+        raise FileNotFoundError(path)
+
+    suffix = p.suffix.lower()
+    if suffix == ".csv":
+        arr = np.loadtxt(p, delimiter=",", dtype=float)
+    elif suffix == ".npy":
+        arr = np.load(p)
+    elif suffix == ".json":
+        with p.open("r", encoding="utf-8") as f:
+            data: Iterable[Iterable[float]] = json.load(f)
+        arr = np.array(data, dtype=float)
+    else:
+        raise ValueError(f"Unsupported file extension: {p.suffix}")
+
+    if arr.ndim != 2:
+        raise ValueError(f"angles must be a 2D array. Got {arr.shape}")
+
+    if deg:
+        arr = np.deg2rad(arr)
+
+    return arr

--- a/ei_vo/core/interpolation.py
+++ b/ei_vo/core/interpolation.py
@@ -1,0 +1,30 @@
+"""Interpolation helpers shared across demos and utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def quintic(q0: np.ndarray, q1: np.ndarray, T: float, dt: float) -> np.ndarray:
+    """Scalar quintic polynomial with zero velocity/acceleration at both ends.
+
+    Parameters
+    ----------
+    q0, q1:
+        Start and end positions (arrays of the same shape).
+    T:
+        Duration of the segment in seconds.
+    dt:
+        Sampling period in seconds.
+
+    Returns
+    -------
+    np.ndarray
+        Array of interpolated positions including both endpoints. The shape is
+        ``(ceil(T/dt)+1, *q0.shape)``.
+    """
+
+    t = np.arange(0.0, T + 1e-12, dt)
+    s = t / max(T, 1e-9)
+    a = 10 * s**3 - 15 * s**4 + 6 * s**5
+    return q0[None, ...] + (q1 - q0)[None, ...] * a[..., None]

--- a/ei_vo/core/recording.py
+++ b/ei_vo/core/recording.py
@@ -1,0 +1,60 @@
+"""Recording-related helpers shared across demos and utilities."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import time
+from typing import Optional, Tuple
+
+
+def resolve_record_destination(
+    record_arg: Optional[os.PathLike | str],
+    *,
+    prefix: str = "demo_",
+    suffix: str = ".mp4",
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve a recording destination from a CLI-style ``--record`` argument.
+
+    Parameters
+    ----------
+    record_arg:
+        Value passed to ``--record``. ``None`` means "no recording". An empty
+        string or a path ending with ``os.sep`` indicates that the caller wants
+        to automatically generate a filename under the given directory (or the
+        default ``./recordings`` directory when empty).
+    prefix:
+        Filename prefix to use when auto-generating a file.
+    suffix:
+        Filename suffix/extension to use when auto-generating a file.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        A pair ``(record_path, auto_dir)``. ``record_path`` is ``None`` when no
+        recording was requested. ``auto_dir`` is the directory that should be
+        created by the caller when an auto-generated filename is used; it is
+        ``None`` when the caller provided a concrete filename.
+    """
+
+    if record_arg is None:
+        return None, None
+
+    record_value = os.fspath(record_arg).strip()
+
+    if record_value == "":
+        base_dir = pathlib.Path.cwd() / "recordings"
+    else:
+        candidate = pathlib.Path(record_value)
+        if record_value.endswith(os.sep):
+            base_dir = candidate
+        elif candidate.exists() and candidate.is_dir():
+            base_dir = candidate
+        else:
+            return candidate.as_posix(), None
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    filename = f"{prefix}{timestamp}{suffix}"
+    record_path = (base_dir / filename).as_posix()
+    return record_path, base_dir.as_posix()
+

--- a/examples/demo_mj.py
+++ b/examples/demo_mj.py
@@ -4,9 +4,6 @@ import argparse
 import inspect
 import math
 import os
-import pathlib
-import sys
-import time
 import types
 import warnings
 
@@ -14,8 +11,11 @@ import numpy as np
 import mujoco as mj
 
 from ei_vo import play
-from ei_vo.core import load_angles, quintic
+from ei_vo.core import load_angles, quintic, resolve_record_destination
 from ei_vo.render import render_mj
+
+# Maintain the previous internal helper name while reusing the shared utility.
+_resolve_record_destination = resolve_record_destination
 
 # ---------------------------
 # Demo trajectory generation (when no angle file is provided)
@@ -64,38 +64,6 @@ def build_sine_demo(dof: int, T_sec: float, hz: float) -> np.ndarray:
 # ---------------------------
 # Main
 # ---------------------------
-def _resolve_record_destination(record_arg):
-    """Resolve the desired recording path.
-
-    Returns a tuple of ``(path_or_none, auto_dir)`` where ``auto_dir`` is the
-    directory that was auto-created when the caller did not supply an explicit
-    filename. ``auto_dir`` is ``None`` when the caller provided a concrete
-    destination.
-    """
-
-    if record_arg is None:
-        return None, None
-
-    record_value = os.fspath(record_arg)
-    record_value = record_value.strip()
-
-    if record_value == "":
-        base_dir = pathlib.Path.cwd() / "recordings"
-    else:
-        candidate = pathlib.Path(record_value)
-        if record_value.endswith(os.sep):
-            base_dir = candidate
-        elif candidate.exists() and candidate.is_dir():
-            base_dir = candidate
-        else:
-            return candidate.as_posix(), None
-
-    timestamp = time.strftime("%Y%m%d-%H%M%S")
-    filename = f"demo_{timestamp}.mp4"
-    record_path = (base_dir / filename).as_posix()
-    return record_path, base_dir.as_posix()
-
-
 def _prepare_play_invocation(args, traj_obj):
     """Build argument lists for ``ei.play`` depending on its signature."""
 

--- a/examples/demo_mj.py
+++ b/examples/demo_mj.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import argparse
 import inspect
-import json
 import math
 import os
 import pathlib
@@ -15,37 +14,8 @@ import numpy as np
 import mujoco as mj
 
 from ei_vo import play
+from ei_vo.core import load_angles, quintic
 from ei_vo.render import render_mj
-
-# ---------------------------
-# Utilities
-# ---------------------------
-def load_angles(path: str, deg: bool) -> np.ndarray:
-    p = pathlib.Path(path)
-    if not p.exists():
-        raise FileNotFoundError(path)
-    if p.suffix.lower() == ".csv":
-        arr = np.loadtxt(p, delimiter=",", dtype=float)
-    elif p.suffix.lower() == ".npy":
-        arr = np.load(p)
-    elif p.suffix.lower() == ".json":
-        with open(p, "r") as f:
-            data = json.load(f)
-        arr = np.array(data, dtype=float)
-    else:
-        raise ValueError(f"Unsupported file extension: {p.suffix}")
-    if arr.ndim != 2:
-        raise ValueError(f"angles must be a 2D array. Got {arr.shape}")
-    if deg:
-        arr = np.deg2rad(arr)
-    return arr
-
-def quintic(q0: np.ndarray, q1: np.ndarray, T: float, dt: float) -> np.ndarray:
-    """Scalar quintic polynomial with zero velocity/acceleration at both ends."""
-    t = np.arange(0.0, T + 1e-12, dt)
-    s = t / max(T, 1e-9)
-    a = 10*s**3 - 15*s**4 + 6*s**5
-    return q0[None, :] + (q1 - q0)[None, :] * a[:, None]
 
 # ---------------------------
 # Demo trajectory generation (when no angle file is provided)

--- a/tests/test_demo_mj.py
+++ b/tests/test_demo_mj.py
@@ -15,7 +15,8 @@ dummy_ei = types.ModuleType("ei")
 dummy_ei.play = lambda *args, **kwargs: None
 sys.modules.setdefault("ei", dummy_ei)
 
-from ei_vo.core import load_angles, quintic
+import ei_vo.core.recording as recording
+from ei_vo.core import load_angles, quintic, resolve_record_destination
 from examples import demo_mj
 
 
@@ -134,6 +135,10 @@ def test_demo_mj_reuses_library_quintic():
     assert demo_mj.quintic is quintic
 
 
+def test_demo_mj_reuses_library_record_resolver():
+    assert demo_mj._resolve_record_destination is resolve_record_destination
+
+
 def test_prepare_play_invocation_skips_record_kwargs_when_not_supported():
     original_play = demo_mj.play
 
@@ -225,7 +230,7 @@ def test_prepare_play_invocation_includes_record_kwargs_when_supported():
 
 def test_resolve_record_destination_defaults_to_recordings(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(demo_mj.time, "strftime", lambda fmt: "20240102-030405")
+    monkeypatch.setattr(recording.time, "strftime", lambda fmt: "20240102-030405")
 
     path, auto_dir = demo_mj._resolve_record_destination("")
 
@@ -239,7 +244,7 @@ def test_resolve_record_destination_defaults_to_recordings(tmp_path, monkeypatch
 def test_resolve_record_destination_accepts_directory(tmp_path, monkeypatch):
     target_dir = tmp_path / "movies"
     target_dir.mkdir()
-    monkeypatch.setattr(demo_mj.time, "strftime", lambda fmt: "20240102-030405")
+    monkeypatch.setattr(recording.time, "strftime", lambda fmt: "20240102-030405")
 
     path, auto_dir = demo_mj._resolve_record_destination(str(target_dir))
 


### PR DESCRIPTION
## Summary
- add shared quintic interpolation helper under `ei_vo.core`
- update MuJoCo demo and tests to consume the shared interpolation utility and export it from package initializers

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695545a29e9883218437fdbf4009f608)